### PR TITLE
Terraform

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -8,6 +8,12 @@ export PROJECT_ROOT
 CLOUDSDK_CORE_PROJECT="gke-cluster-458701"
 export CLOUDSDK_CORE_PROJECT
 
+VAULT_ADDR="$(pass vault/dev/address)"
+export VAULT_ADDR
+
+VAULT_TOKEN="$(pass vault/dev/token)"
+export VAULT_TOKEN
+
 if command -v gcloud >/dev/null 2>&1; then
     gcloud auth configure-docker gcr.io --quiet 2>/dev/null
     echo "✅ gcloud command is available and Docker authentication is configured."

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -109,7 +109,7 @@ resource "null_resource" "vault_init" {
         echo "Unsealing Vault..."
         kubectl exec -n vault-ns vault-0 -- vault operator unseal "$VAULT_UNSEAL_KEY"
 
-        echo "$VAULT_ROOT_TOKEN" > ~/.vault-token
+        # echo "$VAULT_ROOT_TOKEN" > ~/.vault-token
       fi
     EOT
   }
@@ -133,7 +133,7 @@ resource "null_resource" "vault_store_kubeconfig" {
       done
 
       export VAULT_ADDR='http://127.0.0.1:8200'
-      export VAULT_TOKEN=$(cat ~/.vault-token)
+      # export VAULT_TOKEN=$(cat ~/.vault-token)
 
       echo "Backing up current kubeconfig to ~/.kube/config.bak"
       mkdir -p ~/.kube
@@ -148,7 +148,8 @@ resource "null_resource" "vault_store_kubeconfig" {
       cat ~/.kube/config | vault kv put secret/kubeconfig value=-
 
       echo "Stopping port-forward..."
-      kill $PF_PID
+      # kill $PF_PID || true
+      pkill -f 'kubectl port-forward svc/vault -n ${var.vault_ns} 8200:8200' || true
     EOT
   }
 }
@@ -170,7 +171,7 @@ resource "null_resource" "vault_retrieve_kubeconfig" {
       done
 
       export VAULT_ADDR='http://127.0.0.1:8200'
-      export VAULT_TOKEN=$(cat ~/.vault-token)
+      # export VAULT_TOKEN=$(cat ~/.vault-token)
 
       echo "Backing up existing kubeconfig to ~/.kube/config.bak"
       mkdir -p ~/.kube


### PR DESCRIPTION
This pull request introduces improvements to how Vault environment variables are set and modifies the handling of Vault tokens and port-forwarding in Terraform scripts. The main goal is to standardize Vault authentication and cleanup processes, ensuring sensitive information is handled more securely and port-forwarding is reliably terminated.

**Vault environment variable setup:**

* [`.envrc`](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430R11-R16): Added logic to automatically set and export `VAULT_ADDR` and `VAULT_TOKEN` by reading them from the password manager, making Vault authentication easier and more secure.

**Terraform Vault token and port-forwarding changes:**

* [`terraform/vault.tf`](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L112-R112): Commented out lines that previously wrote the Vault root token to `~/.vault-token` and exported it from there, reducing the risk of leaking sensitive tokens. [[1]](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L112-R112) [[2]](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L136-R136) [[3]](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L173-R174)
* [`terraform/vault.tf`](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L151-R152): Improved port-forwarding cleanup by replacing a simple `kill` command with a more robust `pkill` targeting the specific port-forward process, ensuring all relevant processes are terminated.