### PR TITLE
refactor: update helm release set syntax for consistency in monitorin…

### DIFF
--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -9,26 +9,24 @@ resource "helm_release" "prometheus" {
   skip_crds        = false
   wait             = true
 
-  set = [
-    {
-      name  = "grafana.enabled"
-      value = "true"
-    },
-    {
-      name  = "grafana.service.type"
-      value = "ClusterIP"
-    },
-    {
-      name  = "grafana.service.port"
-      value = "80"
-    },
-    {
-      name  = "alertmanager.service.type"
-      value = "ClusterIP"
-    },
-    {
-      name  = "prometheus.service.type"
-      value = "ClusterIP"
-    }
-  ]
+  set {
+    name  = "grafana.enabled"
+    value = "true"
+  }
+  set {
+    name  = "grafana.service.type"
+    value = "ClusterIP"
+  }
+  set {
+    name  = "grafana.service.port"
+    value = "80"
+  }
+  set {
+    name  = "alertmanager.service.type"
+    value = "ClusterIP"
+  }
+  set {
+    name  = "prometheus.service.type"
+    value = "ClusterIP"
+  }
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -18,7 +18,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes = {
+  kubernetes {
     host                   = "https://${google_container_cluster.gke_cluster.endpoint}"
     token                  = data.google_client_config.default.access_token
     cluster_ca_certificate = base64decode(google_container_cluster.gke_cluster.master_auth[0].cluster_ca_certificate)

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -9,56 +9,54 @@ resource "helm_release" "vault" {
 
   create_namespace = true
 
-  set = [
-    {
-      name  = "server.dev.enabled"
-      value = "true"
-    },
-    {
-      name  = "server.ui"
-      value = "true"
-    },
-    {
-      name  = "server.ha.enabled"
-      value = "true"
-    },
-    {
-      name  = "server.ha.replicas"
-      value = "3"
-    },
-    {
-      name  = "server.ha.storage.type"
-      value = "consul"
-    },
-    {
-      name  = "server.ha.storage.consul.address"
-      value = "consul:8500"
-    },
-    {
-      name  = "server.ha.storage.consul.path"
-      value = "vault/"
-    },
-    {
-      name  = "injector.enabled"
-      value = "true"
-    },
-    {
-      name  = "injector.replicaCount"
-      value = "1"
-    },
-    {
-      name  = "injector.authPath"
-      value = "auth/kubernetes"
-    },
-    {
-      name  = "injector.logLevel"
-      value = "info"
-    },
-    {
-      name  = "injector.logLevel"
-      value = "info"
-    }
-  ]
+  set {
+    name  = "server.dev.enabled"
+    value = "true"
+  }
+  set {
+    name  = "server.ui"
+    value = "true"
+  }
+  set {
+    name  = "server.ha.enabled"
+    value = "true"
+  }
+  set {
+    name  = "server.ha.replicas"
+    value = "3"
+  }
+  set {
+    name  = "server.ha.storage.type"
+    value = "consul"
+  }
+  set {
+    name  = "server.ha.storage.consul.address"
+    value = "consul:8500"
+  }
+  set {
+    name  = "server.ha.storage.consul.path"
+    value = "vault/"
+  }
+  set {
+    name  = "injector.enabled"
+    value = "true"
+  }
+  set {
+    name  = "injector.replicaCount"
+    value = "1"
+  }
+  set {
+    name  = "injector.authPath"
+    value = "auth/kubernetes"
+  }
+  set {
+    name  = "injector.logLevel"
+    value = "info"
+  }
+  set {
+    name  = "injector.logLevel"
+    value = "info"
+  }
 }
 
 resource "null_resource" "wait_for_vault" {


### PR DESCRIPTION
This pull request refactors the way Helm chart configuration values are set in the Terraform files for both Prometheus and Vault deployments, and also updates the syntax for the Helm provider configuration. The main improvements are focused on making the Helm `set` blocks more readable and maintainable by switching from array syntax to individual block syntax for each configuration value.

**Helm chart configuration refactoring:**

* In `terraform/monitoring.tf`, the Prometheus Helm release `set` values are now defined using individual `set` blocks instead of a list, improving clarity and maintainability.
* In `terraform/vault.tf`, the Vault Helm release `set` values are similarly refactored to use individual `set` blocks, making each configuration option easier to read and modify.

**Provider configuration update:**

* In `terraform/providers.tf`, the Helm provider configuration is updated to use block syntax for the Kubernetes provider settings, aligning with modern Terraform style.…g.tf, providers.tf, and vault.tf