### PR TITLE
Terraform

### DIFF
--- a/terraform/gke.tf
+++ b/terraform/gke.tf
@@ -13,7 +13,7 @@ data "external" "my_ip" {
 resource "google_container_cluster" "gke_cluster" {
   # checkov:skip=CKV_GCP_69: enabled at the node pool level
   depends_on                  = [google_project_service.api_services]
-  name                        = "demo-cluster"
+  name                        = var.cluster_name
   network                     = google_compute_network.gke_vpc.name
   subnetwork                  = google_compute_subnetwork.gke_subnet.name
   deletion_protection         = false

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,6 +22,12 @@ variable "environment" {
   default     = "dev"
 }
 
+variable "cluster_name" {
+  description = "The name of the GKE cluster."
+  default     = "demo-cluster"
+  type        = string
+}
+
 variable "terraform_state_bucket" {
   type        = string
   description = "The name of the GCS bucket for storing Terraform state."


### PR DESCRIPTION
This pull request makes several improvements to the Terraform configuration for GKE and Vault management. The main changes include parameterizing the GKE cluster name, updating the way port-forwarding processes are stopped, and improving script maintainability.

GKE Cluster configuration:

* Made the GKE cluster name configurable by introducing the `cluster_name` variable in `variables.tf` and updating the cluster resource to use this variable instead of a hardcoded value. [[1]](diffhunk://#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4R25-R30) [[2]](diffhunk://#diff-4f48c3e28850e8792b02c3a7398af7d52fe7108adf230d4a7b010e644ef62a63L16-R16)

Vault management scripts:

* Updated the Vault initialization script to explicitly stop the port-forwarding process using `pkill` if Vault is already initialized, ensuring clean-up of background processes.
* Changed the method for stopping port-forwarding in the Vault kubeconfig storage and retrieval scripts from `pkill` to `kill $PF_PID`, making the process termination more precise and reliable. [[1]](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L143-R151) [[2]](diffhunk://#diff-0c32cd254aedd0688fa82d76acaf18f85700e6244b99c4746b6bfea4767b5e81L194-R196)
* Updated the `gcloud get-credentials` command to use the dynamic cluster name, improving script flexibility across environments.