### PR TITLE
Terraform

### DIFF
--- a/scripts/fwd-services.sh
+++ b/scripts/fwd-services.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Forward ports for services
-kubectl port-forward -n vault-ns svc/vault 8200:8200 &>/dev/null &
-kubectl port-forward -n monitoring-ns svc/prometheus-prometheus-node-exporter 9100:9100 &>/dev/null &
-kubectl port-forward -n monitoring-ns svc/prometheus-grafana 3000:80 &>/dev/null &
-kubectl port-forward -n monitoring-ns svc/prometheus-kube-prometheus-prometheus 9090:9090 &>/dev/null &
+kubectl port-forward -n vault-ns svc/vault 8200:8200 >/tmp/vault-pf.log 2>&1 &
+kubectl port-forward -n monitoring-ns svc/prometheus-prometheus-node-exporter 9100:9100 >/tmp/exporter-pf.log 2>&1 &
+kubectl port-forward -n monitoring-ns svc/prometheus-grafana 3000:80 >/tmp/grafana-pf.log 2>&1 &
+kubectl port-forward -n monitoring-ns svc/prometheus-kube-prometheus-prometheus 9090:9090 >/tmp/prometheus-pf.log 2>&1 &

--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -8,6 +8,7 @@ resource "helm_release" "prometheus" {
   timeout          = 600
   skip_crds        = false
   wait             = true
+  version          = "76.4.0"
 
   set {
     name  = "grafana.enabled"

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -4,7 +4,7 @@ resource "helm_release" "vault" {
   namespace  = var.vault_ns
   repository = "https://helm.releases.hashicorp.com"
   chart      = "vault"
-  version    = "0.28.0"
+  version    = "0.30.1"
   timeout    = 600
 
   create_namespace = true


### PR DESCRIPTION
This pull request updates Helm chart versions for key services and improves the port-forwarding script for better debugging and operational clarity. The main changes are grouped below:

**Helm Chart Version Updates:**

* Upgraded the `vault` Helm chart version from `0.28.0` to `0.30.1` in `terraform/vault.tf` to ensure the latest features and security fixes are available.
* Set the `prometheus` Helm chart version to `76.4.0` in `terraform/monitoring.tf` for improved stability and compatibility.

**Operational Improvements:**

* Modified `scripts/fwd-services.sh` to redirect port-forward logs for Vault, Node Exporter, Grafana, and Prometheus to separate files in `/tmp`, making troubleshooting easier and preventing log clutter in the terminal.