### PR TITLE
refactor: comment out Grafana and Prometheus service settings in helm…

### DIFF
--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -9,25 +9,37 @@ resource "helm_release" "prometheus" {
   skip_crds        = false
   wait             = true
   version          = "76.4.0"
-
-  set {
-    name  = "grafana.enabled"
-    value = "true"
-  }
-  set {
-    name  = "grafana.service.type"
-    value = "ClusterIP"
-  }
-  set {
-    name  = "grafana.service.port"
-    value = "80"
-  }
-  set {
-    name  = "alertmanager.service.type"
-    value = "ClusterIP"
-  }
-  set {
-    name  = "prometheus.service.type"
-    value = "ClusterIP"
-  }
 }
+#   set {
+#     name  = "grafana.enabled"
+#     value = "true"
+#   }
+#   set {
+#     name  = "grafana.service.type"
+#     value = "ClusterIP"
+#   }
+#   set {
+#     name  = "grafana.service.port"
+#     value = "80"
+#   }
+#   set {
+#     name  = "alertmanager.service.type"
+#     value = "ClusterIP"
+#   }
+#   set {
+#     name  = "prometheus.service.type"
+#     value = "ClusterIP"
+#   }
+#   set {
+#     name  = "coreDns.enabled"
+#     value = "true"
+#   }
+#   set {
+#     name  = "coreDns.serviceMonitor.enabled"
+#     value = "true"
+#   }
+#   set {
+#     name  = "prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues"
+#     value = "false"
+#   }
+# }


### PR DESCRIPTION
This pull request updates the configuration for the Prometheus Helm release in `terraform/monitoring.tf`, primarily by modifying the set of enabled services and service monitors. The main changes involve commenting out previous settings and introducing new configuration options for CoreDNS and Prometheus service monitor behavior.

Configuration updates for Helm release:

* Commented out previous settings for enabling Grafana, setting its service type and port, and configuring service types for Alertmanager and Prometheus, making these options inactive for now.
* Added new (commented-out) options to enable CoreDNS, enable CoreDNS service monitoring, and control Prometheus service monitor selector behavior. These provide additional flexibility for future monitoring setup.