### PR TITLE
fix: reorder VAULT_ADDR and VAULT_TOKEN export statements in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -8,12 +8,6 @@ export PROJECT_ROOT
 CLOUDSDK_CORE_PROJECT="gke-cluster-458701"
 export CLOUDSDK_CORE_PROJECT
 
-VAULT_ADDR="$(pass vault/dev/address)"
-export VAULT_ADDR
-
-VAULT_TOKEN="$(pass vault/dev/token)"
-export VAULT_TOKEN
-
 # Detect OS type
 OS_TYPE="$(uname -s)"
 
@@ -90,3 +84,9 @@ if ! command -v pass --version &> /dev/null; then
 else
     echo "pass is already installed."
 fi
+
+VAULT_ADDR="$(pass vault/dev/address)"
+export VAULT_ADDR
+
+VAULT_TOKEN="$(pass vault/dev/token)"
+export VAULT_TOKEN


### PR DESCRIPTION
This pull request updates the `.envrc` file to improve how Vault environment variables are set. The main change is moving the assignment and export of `VAULT_ADDR` and `VAULT_TOKEN` to after the check for the `pass` command, ensuring these variables are only set if `pass` is available.

Environment variable setup improvements:

* Moved the assignment and export of `VAULT_ADDR` and `VAULT_TOKEN` to after the `pass` installation check, ensuring they are set only if the `pass` command is present. [[1]](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430L11-L16) [[2]](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430R87-R92)