### PR TITLE
Direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -77,8 +77,10 @@ ensure_gcloud() {
                 sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
             echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
                 sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
-            apt_update_once
+            sudo apt-get update
             sudo apt-get install -y google-cloud-cli >/dev/null
+    elif ! command -v gcloud >/dev/null 2>&1 && [[ "$OS_TYPE" == "Darwin" ]]; then
+        brew install gcloud-cli
     fi
 }
 


### PR DESCRIPTION
This pull request refactors and improves the `.envrc` setup script to make environment preparation more robust, modular, and compatible across Linux and macOS. The changes enhance package installation logic, add support for additional tools, and clarify environment variable handling.

**Improvements to package installation and environment setup:**

* Refactored the `install_package` function to use a `case` statement for OS detection, add checks for installed packages, and improve output quietness and reliability for both Homebrew and Linux package managers.
* Improved the `ensure_command` and `install_hashicorp_tool` helpers to streamline installation and avoid unnecessary messages, and added the `ensure_hashicorp_repo` function to set up the official HashiCorp APT repository on Linux. [[1]](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430L19-R71) [[2]](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430L93-R116)

**Expanded support for cloud and infrastructure tools:**

* Added new helper functions: `ensure_helm`, `ensure_kubectl`, and `ensure_hashicorp_repo` to automate the setup of Helm, kubectl, and HashiCorp repository on Linux, including proper GPG key and source list configuration.
* Improved `ensure_gcloud` and `ensure_gke_plugin` to better handle installation logic for both Linux and macOS, including proper package manager usage and avoiding redundant installation attempts.

**Environment variable handling:**

* Changed the way `PROJECT_ROOT` is set to be more robust, falling back to `pwd` if `git` is unavailable, and moved the `CLOUDSDK_CORE_PROJECT` export to the end of the file for clarity. [[1]](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430L5-R6) [[2]](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430L118-R150)

**Streamlined tool installation order:**

* Reordered and clarified the sequence of tool installations for consistency, ensuring all required tools (kubectl, helm, HashiCorp tools, etc.) are installed using the appropriate helper functions.