### PR TITLE
fix: update provider versions in versions.tf for compatibility

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -4,13 +4,25 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 5.0"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 7.0"
+    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.20"
+      version = "~> 2.38"
     }
     helm = {
       source  = "hashicorp/helm"
       version = "~> 2.12"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 3.5"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the Terraform provider versions and adds new providers to the `terraform/versions.tf` configuration. These changes ensure compatibility with newer APIs and enable additional functionality.

Provider updates and additions:

* Added the `google-beta` provider with version `~> 7.0` for access to beta features in Google Cloud.
* Updated the `kubernetes` provider to version `~> 2.38` for improved Kubernetes support.
* Added the `http` provider with version `~> 3.5` to allow HTTP data source and resource usage.
* Added the `null` provider with version `~> 3.2` for utility resources such as `null_resource`.