### PR TITLE
feat: add GCP project check to Makefile for validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,16 @@ REPO_NAME=hello-world-repo
 REPO_LOCATION=us
 TF_DIR=terraform
 
-.PHONY: all create-bucket enable-versioning set-lifecycle clean
+.PHONY: check-gcp
+
+check-gcp:
+	@echo "🔍 Checking GCP project: $(GCP_PROJECT)"
+	@if ! gcloud projects describe $(GCP_PROJECT) --format="value(projectId)" | grep -q $(GCP_PROJECT) >/dev/null 2>&1; then \
+		echo "⚠️ Project $(GCP_PROJECT) not found."; \
+		exit 1; \
+	else \
+		echo "✅ GCP project $(GCP_PROJECT) exists."; \
+	fi
 
 tf-bootstrap: tf-bucket tf-format tf-init tf-validate tf-plan
 	@echo "🔄 Runnin terraform bootstrap..."


### PR DESCRIPTION
This pull request introduces a new `check-gcp` target to the `Makefile` for the `hello-world-repo`, which allows users to verify the existence of a specified GCP project before proceeding with further actions.

Makefile enhancements:

* Added a `check-gcp` target that checks if the GCP project defined by `GCP_PROJECT` exists, providing clear success or failure messages and exiting with an error if the project is not found.