### PR TITLE
feat: add update-kubeconfig script for GKE cluster access

### DIFF
--- a/scripts/update-kubeconfig.sh
+++ b/scripts/update-kubeconfig.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# This script fetches credentials for a Google Cloud project and sets up Docker authentication for Google Container Registry (GCR).
+# This script updates the kubeconfig file to access the GKE cluster.
 
 PROJECT_ID="gke-cluster-458701"
 REGION="us-central1"


### PR DESCRIPTION
This pull request renames and updates a script to clarify its purpose and improve its documentation. The script now focuses specifically on updating the kubeconfig file for accessing a GKE cluster.

Script renaming and documentation update:

* Renamed `scripts/fetch-creds.sh` to `scripts/update-kubeconfig.sh` and updated the script comments to clarify that its purpose is to update the kubeconfig file for accessing the GKE cluster, rather than fetching credentials or setting up Docker authentication.