### PR TITLE
feat: ensure Artifact Registry repository exists before building image

### DIFF
--- a/scripts/docker-image.sh
+++ b/scripts/docker-image.sh
@@ -21,6 +21,20 @@ export PROJECT_ROOT
 cd "${PROJECT_ROOT}/kube/" || exit 1
 
 # ------------------------------------------------------------
+# Ensure repo exists
+# ------------------------------------------------------------
+if ! gcloud artifacts repositories describe "$REPO" \
+  --location="$REGION" --project="$PROJECT_ID" >/dev/null 2>&1; then
+  echo "📦 Creating Artifact Registry repo: $REPO..."
+  gcloud artifacts repositories create "$REPO" \
+    --repository-format=docker \
+    --location="$REGION" \
+    --project="$PROJECT_ID"
+else
+  echo "✅ Artifact Registry repo $REPO exists."
+fi
+
+# ------------------------------------------------------------
 # Image path
 # ------------------------------------------------------------
 IMAGE_PATH="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/${IMAGE_NAME}"
@@ -70,20 +84,6 @@ fi
 
 echo "🔑 Configuring docker credential helper for GAR..."
 gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
-
-# ------------------------------------------------------------
-# Ensure repo exists
-# ------------------------------------------------------------
-if ! gcloud artifacts repositories describe "$REPO" \
-  --location="$REGION" --project="$PROJECT_ID" >/dev/null 2>&1; then
-  echo "📦 Creating Artifact Registry repo: $REPO..."
-  gcloud artifacts repositories create "$REPO" \
-    --repository-format=docker \
-    --location="$REGION" \
-    --project="$PROJECT_ID"
-else
-  echo "✅ Artifact Registry repo $REPO exists."
-fi
 
 # ------------------------------------------------------------
 # Build + Push


### PR DESCRIPTION
This pull request refactors the logic for ensuring the existence of the Artifact Registry repository in the `scripts/docker-image.sh` script. The main change is moving the repo existence check and creation earlier in the script, before building and pushing the Docker image.

Refactoring and workflow improvements:

* Moved the block that checks for the existence of the Artifact Registry repository (`$REPO`) and creates it if necessary to an earlier position in the script, right after changing directories to `${PROJECT_ROOT}/kube/`. This ensures the repository is available before any image build or push operations begin.
* Removed the same block from its previous location, which was after Docker credential configuration and before the image build and push steps, to avoid redundant checks and streamline the workflow.