### PR TITLE
feat: add script to update kubeconfig for GKE cluster access

### DIFF
--- a/scripts/update-kubeconfig.py
+++ b/scripts/update-kubeconfig.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+This script updates the kubeconfig file to access the GKE cluster.
+"""
+
+import subprocess
+import sys
+
+PROJECT_ID = "gke-cluster-458701"
+REGION = "us-central1"
+CLUSTER_NAME = "demo-cluster"
+
+def main():
+    cmd = [
+        "gcloud", "container", "clusters", "get-credentials",
+        CLUSTER_NAME,
+        "--region", REGION,
+        "--project", PROJECT_ID
+    ]
+    try:
+        print(f"Running: {' '.join(cmd)}")
+        subprocess.check_call(cmd)
+        print("✅ kubeconfig updated successfully.")
+    except subprocess.CalledProcessError as e:
+        print(f"❌ Failed to update kubeconfig: {e}", file=sys.stderr)
+        sys.exit(e.returncode)
+
+if __name__ == "__main__":
+        main()


### PR DESCRIPTION
This pull request adds a new script to automate updating the kubeconfig file for accessing a GKE cluster. The script provides a simple way to configure local Kubernetes access using the correct project, region, and cluster settings.

New script for cluster configuration:

* Added `scripts/update-kubeconfig.py` to automate updating the kubeconfig using `gcloud` for the `demo-cluster` in project `gke-cluster-458701` and region `us-central1`.