### PR TITLE
fix: update required Terraform version and provider versions in versi…

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.13.0"
 
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.0"
+      version = "~> 5.45"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
@@ -28,7 +28,7 @@ terraform {
     }
     vault = {
       source  = "hashicorp/vault"
-      version = "~> 3.21"
+      version = "~> 5.2"
     }
     external = {
       source  = "hashicorp/external"


### PR DESCRIPTION
This pull request updates the required Terraform and provider versions in the `terraform/versions.tf` file to ensure compatibility with newer features and security updates.

Version upgrades:

* Increased the minimum required Terraform version from `1.5.0` to `1.13.0` to support newer Terraform features and syntax.
* Updated the `google` provider version from `~> 5.0` to `~> 5.45` for improved compatibility and access to the latest Google Cloud resources.
* Upgraded the `vault` provider version from `~> 3.21` to `~> 5.2` to include recent Vault provider enhancements and fixes.…ons.tf