### PR TITLE
refactor: rename 'clean' target to 'nuke' in Makefile for clarity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ add-labels:
 	gcloud storage buckets update gs://$(BUCKET_NAME) \
 		--update-labels=environment=terraform,purpose=state-storage
 
-clean:
+nuke:
 	@echo "⚠️  This will delete the bucket: $(BUCKET_NAME)"
 	@read -p "Are you sure? (y/N): " confirm; \
 	if [ "$$confirm" = "y" ]; then \


### PR DESCRIPTION
This pull request makes a minor change to the `Makefile`, replacing the `clean` target with a new `nuke` target that prompts for confirmation before deleting the bucket.