### PR TITLE
fix: update image_digest variable to correct Docker image digest

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -66,7 +66,7 @@ variable "image_tag" {
 
 variable "image_digest" {
   description = "Digest of the Docker image to be used in the deployment"
-  default     = "sha256:fdafa75e133d87b15f2df802121b91eccc48cca3e50d40df0835fd7383d9f8eb"
+  default     = "sha256:cf7df76bcd16d5bb58cf482492e97e0c3fc897494f7a60a05ca84dcee5eb0ed8"
   type        = string
 }
 


### PR DESCRIPTION
This pull request updates the default Docker image digest used for deployments in the Terraform configuration. This ensures that new deployments will use the latest specified image version.

* Updated the `image_digest` variable in `terraform/variables.tf` to use a new Docker image digest as the default value.