### PR TITLE
fix: update docker buildx configuration and enable credential helper …

### DIFF
--- a/scripts/docker-image.sh
+++ b/scripts/docker-image.sh
@@ -64,26 +64,27 @@ if ! docker buildx version &> /dev/null; then
 fi
 
 # Ensure buildx builder exists
-if ! docker buildx inspect multiarch >/dev/null 2>&1; then
-  docker buildx create --name multiarch --use
+if ! docker buildx inspect mybuilder >/dev/null 2>&1; then
+  docker buildx create --name mybuilder --driver docker-container --use
+  docker buildx inspect --bootstrap
 else
-  docker buildx use multiarch
+  docker buildx use mybuilder
 fi
 
 # ------------------------------------------------------------
 # Ensure docker credential helper
 # ------------------------------------------------------------
-# if ! command -v docker-credential-gcr >/dev/null 2>&1 && [[ "$OS_TYPE" == "Linux" ]]; then
-#     echo "🔧 Installing docker-credential-gcr..."
-#     sudo apt-get update -qq
-#     sudo apt-get install -y google-cloud-cli-docker-credential-gcr
-#   elif ! command -v docker-credential-osxkeychain >/dev/null 2>&1 && [[ "$OS_TYPE" == "Darwin" ]]; then
-#     echo "🔧 Installing docker-credential-helper for Mac..."
-#     brew install docker-credential-helper
-# fi
+if ! command -v docker-credential-gcr >/dev/null 2>&1 && [[ "$OS_TYPE" == "Linux" ]]; then
+    echo "🔧 Installing docker-credential-gcr..."
+    sudo apt-get update -qq
+    sudo apt-get install -y google-cloud-cli-docker-credential-gcr
+  elif ! command -v docker-credential-osxkeychain >/dev/null 2>&1 && [[ "$OS_TYPE" == "Darwin" ]]; then
+    echo "🔧 Installing docker-credential-helper for Mac..."
+    brew install docker-credential-helper
+fi
 
-# echo "🔑 Configuring docker credential helper for GAR..."
-# gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+echo "🔑 Configuring docker credential helper for GAR..."
+gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
 
 # ------------------------------------------------------------
 # Build + Push


### PR DESCRIPTION
This pull request updates the `scripts/docker-image.sh` script to improve the Docker buildx setup and automate Docker credential helper installation and configuration. The most important changes are grouped below:

**Docker buildx builder improvements:**

* Changed the buildx builder name from `multiarch` to `mybuilder`, specified the `docker-container` driver, and ensured the builder is bootstrapped after creation. The script now consistently uses `mybuilder` for all buildx operations.

**Docker credential helper automation:**

* Un-commented and enabled logic to automatically install the appropriate Docker credential helper (`docker-credential-gcr` for Linux, `docker-credential-osxkeychain` for macOS) based on the OS type.
* Un-commented and enabled configuration of Docker authentication for Google Artifact Registry (GAR) using `gcloud auth configure-docker`.