### PR TITLE
fix: correct environment variable usage and enhance Docker Buildx setup

### DIFF
--- a/.github/workflows/gke-deploy.yml
+++ b/.github/workflows/gke-deploy.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
         with:
-          project_id: ${{ vars.GCP_PROJECT_ID }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
 
       - name: Authenticate Docker to Google Artifact Registry
         run: |
@@ -153,6 +153,8 @@ jobs:
       - name: Set up Docker Buildx builder and Build Docker image
         if: steps.image-check.outputs.exists == 'false'
         run: |
-          docker buildx create --name mybuilder --driver docker-container --use
+          if ! docker buildx inspect mybuilder >/dev/null 2>&1; then
+            docker buildx create --name mybuilder --driver docker-container --use
+          fi
           docker buildx inspect --bootstrap
           docker buildx build --platform linux/amd64,linux/arm64 -t ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.REPO_NAME }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} -f kube/Dockerfile kube/ --push


### PR DESCRIPTION
This pull request makes improvements to the deployment workflow in `.github/workflows/gke-deploy.yml`, focusing on environment variable usage and robustness of Docker image building.

Workflow configuration updates:

* Changed the `project_id` reference in the Google Cloud SDK setup step to use `env.GCP_PROJECT_ID` instead of `vars.GCP_PROJECT_ID`, ensuring consistency with other environment variables.

Docker build process improvements:

* Added a check before creating the Docker Buildx builder to prevent errors if the builder already exists, improving the reliability of the Docker image build step.