### PR TITLE
refactor: rename repository variable and streamline existence check in docker-image script

### DIFF
--- a/scripts/docker-image.sh
+++ b/scripts/docker-image.sh
@@ -27,7 +27,10 @@ if ! gcloud artifacts repositories describe "$REPO_NAME" \
   echo "📦 Creating Artifact Registry repo: $REPO_NAME..."
   gcloud artifacts repositories create "$REPO_NAME" \
     --location="$REGION" \
-    --project="$PROJECT_ID"
+    --project="$PROJECT_ID" \
+    --repository-format=docker \
+    --description="Docker repository for $IMAGE_NAME"
+  echo "✅ Artifact Registry repo $REPO_NAME created."
 else
   echo "✅ Artifact Registry repo $REPO_NAME already exists."
 fi


### PR DESCRIPTION
This pull request updates the `scripts/docker-image.sh` script to improve consistency in variable naming and streamline Artifact Registry and Docker credential helper setup. The changes primarily focus on refactoring variable names, enabling previously commented-out logic, and simplifying the image existence check.

**Artifact Registry setup and variable naming:**

* Renamed the repository variable from `REPO` to `REPO_NAME` throughout the script for clarity and consistency. [[1]](diffhunk://#diff-090c30899dee381723a9fdde7ceb8ed16428ddadccb7fcfea02a116082c17249L12-L16) [[2]](diffhunk://#diff-090c30899dee381723a9fdde7ceb8ed16428ddadccb7fcfea02a116082c17249L25-R44)
* Enabled and updated the logic to check for the existence of the Artifact Registry repository, creating it if necessary, and providing clearer messaging.
* Updated the `IMAGE_PATH` variable to use `REPO_NAME` instead of the old `REPO` variable.

**Docker credential helper setup:**

* Removed OS-specific installation logic for Docker credential helpers and replaced it with a simplified check and installation using `gcloud components install docker-credential-gcr`.

**Image existence check:**

* Simplified the check for an existing image tag in Artifact Registry by removing the redundant `--project` flag from the `gcloud artifacts docker images describe` command.