### PR TITLE
fix: update IMAGE_TAG to use github.sha instead of hardcoded version

### DIFF
--- a/.github/workflows/gke-deploy.yml
+++ b/.github/workflows/gke-deploy.yml
@@ -20,7 +20,8 @@ env:
   GCP_REGION: ${{ vars.GCP_REGION }}
   IMAGE_NAME: hello-world
   REPO_NAME: hello-world-repo
-  IMAGE_TAG: 1.2.3
+  # IMAGE_TAG: 1.2.3
+  IMAGE_TAG: ${{ github.sha }}
 
 jobs:
   terraform-apply:


### PR DESCRIPTION
This pull request updates the deployment workflow to improve traceability of Docker images by using the current commit SHA as the image tag instead of a static version number.

Deployment workflow update:

* [`.github/workflows/gke-deploy.yml`](diffhunk://#diff-7f4531bd19c56f8f84310851f0788f8ef5ba921baf5c0efda0f2814fad95a17aL23-R24): Changed `IMAGE_TAG` to use `${{ github.sha }}` instead of the hardcoded `1.2.3`, ensuring each build is tagged with its unique commit SHA.